### PR TITLE
a little bit ugly, but fixes the layout shift with player

### DIFF
--- a/app/pages/docs/$$.mjs
+++ b/app/pages/docs/$$.mjs
@@ -31,6 +31,11 @@ export default function ({ html, state }) {
         border-radius: 8px;
         background-color: var(--grey-greyer);
       }
+
+      doc-video {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+      }
     </style>
 
     <docs-symbols></docs-symbols>


### PR DESCRIPTION
The issue is that:

- `<doc-video>` doesn't take up any space on initial load
- I tried adding `width: 100%; aspect-ratio: 16 / 9` to the `::host` on `doc/video.mjs`, and those styles get applied, but they get applied after the custom element constructor has been run

Ultimately, the only way to prevent layout shift from happening is to apply sizing styles to the element in the light dom, so you don't have to wait for any JS to be loaded / parsed / initialized

Screen recording: https://stream.new/v/6qBFJsJKFHINfhZhAvZOPwiTD00OKiJrKccDIvNh4ym00
