### PR TITLE
update Quick Start document to specify Node 17

### DIFF
--- a/app/docs/md/index.md
+++ b/app/docs/md/index.md
@@ -13,7 +13,7 @@ Enhance is a web standards-based HTML framework. It's designed to provide a depe
 
 ## Get started
 
-To create a project, ensure you have <a href=https://nodejs.org>Node.js 16.x</a> or higher installed, and run:
+To create a project, ensure you have <a href=https://nodejs.org>Node.js 17.x</a> or higher installed, and run:
 
 ```bash
 npm create "@enhance" ./myproject -y


### PR DESCRIPTION
I followed the  "Get started" instructions using Node 16.3.0 and the installation failed:
```
$ node --version
v16.3.0
$ npm create "@enhance" ./myproject
file:///Users/daniel/.npm/_npx/3893a12bf086031f/node_modules/@enhance/create/index.mjs:2
import { cp, rename } from 'node:fs/promises'
         ^^
SyntaxError: The requested module 'node:fs/promises' does not provide an export named 'cp'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:121:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:171:5)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
npm ERR! code 1
npm ERR! path /Users/daniel/workspace/enhance
npm ERR! command failed
npm ERR! command sh -c -- enhance-create ./myproject
```
I upgraded Node to 17.0.0 and the installation command succeeded.

```
$  node --version
v17.0.0
$ npm create "@enhance" ./myproject -
Created /Users/daniel/workspace/enhance/myproject

--- to get started run the following commands ---
cd ./myproject
npm install
npm start
```
Consequently, I suggest updating the installation instructions to specify Node 17 or higher.

Note: I installed Node with the version manager `asdf` which was installed with Homebrew.