### PR TITLE
<doc-video> features

### DIFF
--- a/app/docs/md/by-example/videos.md
+++ b/app/docs/md/by-example/videos.md
@@ -1,0 +1,14 @@
+---
+title: Enhance Tutorial Videos
+comment: A list of videos that works without JS enabled
+---
+
+## Enhance Quick Start Tutorial
+
+<doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU" name="Enhance Quick Start">
+</doc-video>
+
+## Quick Start Tutorial part 2
+
+<doc-video playback-id="uEucxWZZUxE9BAa02DH00w8C6d89viqBYd4nHU02NFFi7c" name="Quick Start pt 2">
+</doc-video>

--- a/app/docs/md/index.md
+++ b/app/docs/md/index.md
@@ -8,7 +8,8 @@ Enhance is a web standards-based HTML framework. It's designed to provide a depe
 
 ## Video Walkthrough
 
-<doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU" title="Enhance Quick Start">
+<doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU" name="Enhance Quick Start">
+  <doc-video-next playback-id="uEucxWZZUxE9BAa02DH00w8C6d89viqBYd4nHU02NFFi7c" name="Quick Start pt 2"></doc-video-next>
 </doc-video>
 
 ## Get started

--- a/app/docs/md/unsorted/doc-video-test.md
+++ b/app/docs/md/unsorted/doc-video-test.md
@@ -2,4 +2,14 @@
 title: Doc Video
 ---
 
-<doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU"></doc-video>
+## Video Walkthrough
+
+This is a set of 5 videos that starts at the third in the series.  
+Most of the videos don't actually work -- it's here to test the series feature in the player
+
+<doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU" name="Video pt 1: Tutorial">
+  <doc-video-prev playback-id="foobarbaz" name="Video pt -1"></doc-video-next>
+  <doc-video-prev playback-id="fizzbuzz" name="Video pt 0"></doc-video-next>
+  <doc-video-next playback-id="uEucxWZZUxE9BAa02DH00w8C6d89viqBYd4nHU02NFFi7c" name="Video pt 2"></doc-video-next>
+  <doc-video-next playback-id="uEucxWZZUxE9BAa02DH00w8C6d89viqBYd4nHU02NFFi7c" name="Video pt 3"></doc-video-next>
+</doc-video>

--- a/app/elements/doc/video.mjs
+++ b/app/elements/doc/video.mjs
@@ -3,7 +3,7 @@ import arc from '@architect/functions'
 export default function DocVideo({ html, state }) {
   const { attrs } = state
   const playbackId = attrs['playback-id']
-  const title = attrs.title || 'Enhance Video'
+  const name = attrs.name || 'Enhance Video'
 
   return html`
     <style>
@@ -24,6 +24,60 @@ export default function DocVideo({ html, state }) {
         display: none;
       }
 
+      nav {
+        position: absolute;
+        z-index: 100;
+        bottom: 0;
+        left: 0;
+      }
+      nav a {
+        position: absolute;
+        z-index: -1;
+        bottom: 0;
+        left: 0;
+        padding-right: 0.5rem;
+        text-align: center;
+        font-size: 1.5rem;
+      }
+
+      nav ul {
+        margin: 0 0 0.5rem 1.3rem;
+        padding: 0.5rem;
+        list-style: none;
+        cursor: pointer;
+        color: var(--purple-princess);
+        background: var(--cloud-ateneo);
+        box-shadow: rgb(0 0 0 / 10%) 0px 1px 3px 0px,
+          rgb(0 0 0 / 6%) 0px 1px 2px 0px;
+      }
+      nav ul li {
+        width: auto;
+        padding: 0.5rem;
+        border-radius: 0.25rem;
+      }
+      nav ul li.current {
+        color: var(--inky-lily);
+      }
+      nav ul li.current::before {
+        content: '› ';
+      }
+
+      nav ul.hide {
+        transition: max-height 0.3s ease-out;
+        overflow: hidden;
+        visibility: hidden;
+        max-height: 0;
+        max-width: 0;
+      }
+      @media (hover: hover) {
+        /* don't apply hover on touchstart */
+        nav:hover ul.hide {
+          max-height: 500px;
+          max-width: unset;
+          visibility: visible;
+        }
+      }
+
       cite {
         position: absolute;
         bottom: 0;
@@ -34,6 +88,13 @@ export default function DocVideo({ html, state }) {
       }
     </style>
 
+    <div data-doc-video="next-videos" class="hidden">
+      <doc-video-current
+        playback-id="${playbackId}"
+        name="${name}"></doc-video-current>
+      <slot></slot>
+    </div>
+
     <video
       class="placeholder"
       src="https://stream.mux.com/${playbackId}/medium.mp4"
@@ -42,7 +103,12 @@ export default function DocVideo({ html, state }) {
     <mux-player
       stream-type="on-demand"
       playback-id="${playbackId}"
-      metadata-video-title="${title}"></mux-player>
+      metadata-video-title="${name}"></mux-player>
+
+    <nav class="doc-video-menu hidden">
+      <ul class="hide"></ul>
+      <a>☰</a>
+    </nav>
 
     <cite>
       Powered by
@@ -57,21 +123,8 @@ export default function DocVideo({ html, state }) {
       type="module"
       src="${arc.static('/bundles/mux-player.mjs')}"></script>
 
-    <script type="module">
-      class DocVideo extends HTMLElement {
-        constructor() {
-          super()
-          this.video = this.querySelector('video.placeholder')
-          this.player = this.querySelector('mux-player')
-        }
-
-        connectedCallback() {
-          this.video.remove()
-          this.player.style.display = 'block'
-        }
-      }
-
-      customElements.define('doc-video', DocVideo)
-    </script>
+    <script
+      type="module"
+      src="${arc.static('/js/elements/doc-video.mjs')}"></script>
   `
 }

--- a/public/js/elements/doc-video.mjs
+++ b/public/js/elements/doc-video.mjs
@@ -1,0 +1,95 @@
+/* eslint-disable fp/no-class */
+class DocVideo extends HTMLElement {
+  constructor() {
+    super()
+    this.allVids = []
+    this.currIndex = 0
+    this.$video = this.querySelector('video.placeholder')
+    this.$player = this.querySelector('mux-player')
+    this.$menu = this.querySelector('nav.doc-video-menu ul')
+    this.$menuToggle = this.querySelector('nav.doc-video-menu a')
+
+    const $prevVids = this.querySelectorAll('doc-video-prev')
+    const $currVid = this.querySelector('doc-video-current')
+    const $nextVids = this.querySelectorAll('doc-video-next')
+    if ($prevVids) {
+      this.allVids = Array.from($prevVids).map(this.getData)
+    }
+    if ($currVid) {
+      const currVid = this.getData($currVid)
+      this.currIndex = this.allVids.length
+      this.allVids.push(currVid)
+    }
+    if ($nextVids) {
+      this.allVids = [
+        ...this.allVids,
+        ...Array.from($nextVids).map(this.getData),
+      ]
+    }
+  }
+
+  getData($el) {
+    return {
+      playbackId: $el.getAttribute('playback-id'),
+      name: $el.getAttribute('name'),
+    }
+  }
+
+  renderVidMenu() {
+    if (this.$menu) {
+      const list = []
+      for (const [index, vid] of this.allVids.entries()) {
+        const li = document.createElement('li')
+        li.addEventListener('click', this.changePlaverVid.bind(this, vid))
+        li.textContent = vid.name
+        if (index === this.currIndex) {
+          li.classList.add('current')
+        }
+        list.push(li)
+      }
+
+      this.$menu.replaceChildren(...list)
+    }
+  }
+
+  showVidMenu() {
+    this.$menu?.classList.remove('hide')
+  }
+  hideVidMenu() {
+    this.$menu?.classList.add('hide')
+  }
+  toggleVidMenu() {
+    this.$menu?.classList.toggle('hide')
+  }
+
+  changePlaverVid(vid) {
+    if (this.$player) {
+      const newIndex = this.allVids.indexOf(vid)
+      this.currIndex = newIndex
+      this.$player.setAttribute('playback-id', vid.playbackId)
+      this.renderVidMenu()
+    }
+  }
+
+  connectedCallback() {
+    if (this.$video && this.$player) {
+      this.$video.remove()
+      this.$player.classList.add('block')
+
+      if (this.allVids.length > 1 && this.$menu && this.$menuToggle) {
+        this.renderVidMenu()
+        this.$menu.parentElement?.classList.remove('hidden')
+
+        this.$player.addEventListener('pause', this.showVidMenu.bind(this))
+        this.$player.addEventListener('ended', this.showVidMenu.bind(this))
+        this.$player.addEventListener('play', this.hideVidMenu.bind(this))
+        this.$menuToggle.addEventListener(
+          'touchstart',
+          this.toggleVidMenu.bind(this)
+        )
+      }
+    }
+  }
+}
+
+customElements.define('doc-video', DocVideo)


### PR DESCRIPTION
Improve `<doc-video>` so that it can display a video "series". This is mostly done with an addon menu that is available when the doc-video element is created with additional `<doc-video-prev>` or `<doc-video-next>`.

The menu expands when hovered (or tapped on mobile), when the player is paused (hides when playing), and when the current video ends.

The gif makes more sense 😃 

![Enhance_doc-video_demo](https://user-images.githubusercontent.com/15697/194223109-fabff8dd-044b-4d2a-a944-a5dd0e68b0d1.gif)

### Possible future improvements

We can probably integrate this into the `<mux-player>` element. Use an icon that matches the existing ones in their player controls and make it feel more "native" to the player.
