### PR TITLE
404 had a stray p-tag

### DIFF
--- a/app/pages/404.mjs
+++ b/app/pages/404.mjs
@@ -181,7 +181,7 @@ export default function FourOh4({ html, state }) {
         ">
           ${term
             ? 'Do you want to search?'
-            : '<p>Do you want to see the <a href=/docs/>Docs</a>?'}
+            : 'Do you want to see the <a href=/docs/>Docs</a>?'}
         </p>
         ${term
           ? `<button class="radius-2 pt-2 pr1 pb-2 pl1 font-semibold">


### PR DESCRIPTION
There was a stray p-tag messing up the styles. But there are also a few other things to check.

@tbeseda I think the 404 search button inside docs is broken. I have not worked with the algolia search so I am guessing it is  something simple you might spot. 

Also, @kristoferjoseph just wondering if you see anything you would like changed here. I threw it together when shipping the enhance version of this and never got a chance to run it by anyone else. 