### PR TITLE
docs: update Fastify example

### DIFF
--- a/app/docs/md/learn/deployment/fastify.md
+++ b/app/docs/md/learn/deployment/fastify.md
@@ -168,6 +168,7 @@ Navigating to `/fruits` will show an empty list. Create an API route to populate
 
 ```javascript
 export async function get (req) {
+  const fruits = ["apples", "mangos", "pears"]
   return {
     json: { fruits }
   }


### PR DESCRIPTION
The last code example for navigating to `/fruits` will return a 500 response due to `fruits` not existing.

Added some initial data to return in the response so that the 500 error response no longer occurs.