### PR TITLE
Various documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ livereload true
 
 ### Main site
 
-Currently redirects to Enhance documentation at "/docs/".
+Currently redirects to the Enhance documentation at "/docs/".
 
 ### Docs engine
 

--- a/app/docs/md/by-example/examples/browser-testing.md
+++ b/app/docs/md/by-example/examples/browser-testing.md
@@ -39,7 +39,7 @@ This will let us test components in isolation and/or in combination without boot
 
 ### Install Playwright
 
-In an establised Enhance app, we'll follow [Playwright's Getting Started guide](https://playwright.dev/docs/intro).
+In an established Enhance app, we'll follow [Playwright's Getting Started guide](https://playwright.dev/docs/intro).
 
 ```shell
 npm init playwright@latest

--- a/app/docs/md/by-example/examples/browser-testing.md
+++ b/app/docs/md/by-example/examples/browser-testing.md
@@ -138,13 +138,13 @@ For this example, we'll add pages/counter.html:
 <doc-callout level="caution">
 
 Don't delete tests/mock/app/pages/index.html.
-Playwright is configured to check the root of our webserver to make sure it has booted before running tests.
+Playwright is configured to check the root of our web server to make sure it has booted before running tests.
 
 </doc-callout>
 
 #### 4. Run the mock app
 
-We can verify our set up by running `npm start` in mock/ and visiting localhost:3333/counter.
+We can verify our setup by running `npm start` in mock/ and visiting localhost:3333/counter.
 In this case, we will see our component rendered once.
 
 ### Write a test

--- a/app/docs/md/by-example/examples/browser-testing.md
+++ b/app/docs/md/by-example/examples/browser-testing.md
@@ -7,7 +7,7 @@ read-next:
   label: Read more about testing Enhance output
   mark: 🔬
   path: /docs/learn/practices/testing
-  description: Enhance custom elements return strings on the server, making them easy to test for expected output.
+  description: Enhance's custom elements return strings on the server, making them easy to test for expected output.
 docs-pager: false
 ---
 

--- a/app/docs/md/by-example/examples/browser-testing.md
+++ b/app/docs/md/by-example/examples/browser-testing.md
@@ -30,7 +30,7 @@ We're still experimenting with the ideal setup before publishing findings and an
 
 ## Playwright + Enhance
 
-[Playwright](https://playwright.dev/) is a cross-browser test runner commonly used for end-to-end (E2E) testing.  
+[Playwright](https://playwright.dev/) is a cross-browser test runner commonly used for end-to-end (E2E) testing.
 It works by steering an automated browser to a web server, executing interactions, and then making assertions.
 All without even having to open a browser window (headless).
 

--- a/app/docs/md/by-example/examples/custom-events.md
+++ b/app/docs/md/by-example/examples/custom-events.md
@@ -14,7 +14,7 @@ Similar to how a `<button>` might listen for a click event, your web component (
 
 ## Enhance has a data API built in
 
-This particular `CustomEvent` approach has a narrow use-case if you're already leveraging Enhance in your peroject.
+This particular `CustomEvent` approach has a narrow use-case if you're already leveraging Enhance in your project.
 You can likely solve any pub/sub challenge with Enhance's features with less code.
 However, it's totally possible to use JavaScript's built in primitives as described here.
 

--- a/app/docs/md/by-example/examples/custom-events.md
+++ b/app/docs/md/by-example/examples/custom-events.md
@@ -54,7 +54,7 @@ And you can broadcast that event from elsewhere in your HTML document.
 
 <doc-code callout="1-'giddyup'">
 
-```javascript 
+```javascript
 const giddyupEvent = new CustomEvent('giddyup', { direction: 'west' })
 window.horse.dispatchEvent(giddyup)
 ```

--- a/app/docs/md/by-example/examples/custom-events.md
+++ b/app/docs/md/by-example/examples/custom-events.md
@@ -16,7 +16,7 @@ Similar to how a `<button>` might listen for a click event, your web component (
 
 This particular `CustomEvent` approach has a narrow use-case if you're already leveraging Enhance in your project.
 You can likely solve any pub/sub challenge with Enhance's features with less code.
-However, it's totally possible to use JavaScript's built in primitives as described here.
+However, it's totally possible to use JavaScript's built-in primitives as described here.
 
 </doc-callout>
 

--- a/app/docs/md/by-example/examples/standalone-enhance.md
+++ b/app/docs/md/by-example/examples/standalone-enhance.md
@@ -17,7 +17,7 @@ This approach to using Enhance is essentially string munging (albeit very sophis
 ## Single file example
 
 In this guide we'll create a single-file module that exports a handler function leveraging `enhance-ssr` to compose an HTML document with a component where state is carried from the request to the custom element.
-We'll use the familiar method signature of `(request, <reply>)` to handle incoming requests. 
+We'll use the familiar method signature of `(request, <reply>)` to handle incoming requests.
 
 ### Set up the basics
 

--- a/app/docs/md/by-example/examples/standalone-enhance.md
+++ b/app/docs/md/by-example/examples/standalone-enhance.md
@@ -19,7 +19,7 @@ This approach to using Enhance is essentially string munging (albeit very sophis
 In this guide we'll create a single-file module that exports a handler function leveraging `enhance-ssr` to compose an HTML document with a component where state is carried from the request to the custom element.
 We'll use the familiar method signature of `(request, <reply>)` to handle incoming requests. 
 
-### Setup the basics
+### Set up the basics
 
 <doc-code filename="get-index.js" numbered>
 

--- a/app/docs/md/by-example/index.md
+++ b/app/docs/md/by-example/index.md
@@ -2,7 +2,7 @@
 title: By Example Home
 ---
 
-Guides with discrete steps.  
+Guides with discrete steps.
 Like a recipe.
 
 Less thoughtful guides on "why"; more step-by-step "how".

--- a/app/docs/md/by-example/integrations/with-alpinejs.md
+++ b/app/docs/md/by-example/integrations/with-alpinejs.md
@@ -5,7 +5,7 @@ links:
 docs-pager: false
 ---
 
-Since Enhance renders "just" HTML, you can use other tools that work with vanilla HTML.  
+Since Enhance renders "just" HTML, you can use other tools that work with vanilla HTML.
 [Alpine.js](https://alpinejs.dev) is a minimal, but powerful, framework for adding interactivity to your application without writing much actual JavaScript.
 
 <doc-callout level="info">
@@ -67,5 +67,5 @@ This component can now be used from any HTML page in your Enhance application.
 ```
 
 </doc-code>
-  
+
 ![alpine.js collapse example animation](img/gif/example-alpinejs-collapse.gif)

--- a/app/docs/md/by-example/integrations/with-typescript.md
+++ b/app/docs/md/by-example/integrations/with-typescript.md
@@ -17,7 +17,7 @@ But targeting [the conventional /app file structure](/docs/learn/starter-project
 
 <doc-callout level="tip" mark="📢">
 
-**If you've built a novel way to add whole-project compilation to Enhance, let us know!**  
+**If you've built a novel way to add whole-project compilation to Enhance, let us know!**
 And if you see any opportunities for improving the official types or this doc, feel free to file issues and/or open a PR.
 We're always open to outside contribution, especially from domain experts.
 
@@ -33,7 +33,7 @@ Some options for transpiling your TypeScript to JavaScript for Node.js:
 
 <doc-callout level="caution">
 
-Be wary of build tools that are intended for client side projects. With an "HTML first" principle, most of Enhance is executing in a server-side Node.js environment.  
+Be wary of build tools that are intended for client side projects. With an "HTML first" principle, most of Enhance is executing in a server-side Node.js environment.
 Read more about [using TS to build Web Component definitions for the browser with `@bundles`](/docs/learn/practices/browser-modules#typescript-web-components).
 
 </doc-callout>

--- a/app/docs/md/index.md
+++ b/app/docs/md/index.md
@@ -36,7 +36,7 @@ The source for the index page can be found in your app at `app/pages/index.html`
 
 ```
 app
-└── pages ............. file based routing
+└── pages ............. file-based routing
     └── index.html
 ```
 
@@ -65,7 +65,7 @@ Your project should now look like this:
 ```
 app
 ├── elements .......... custom element pure functions
-└── pages ............. file based routing
+└── pages ............. file-based routing
     ├── about.html
     └── index.html
 ```
@@ -101,7 +101,7 @@ Your project should now look like this:
 app
 ├── elements .......... custom element pure functions
 │   └── my-header.mjs
-└── pages ............. file based routing
+└── pages ............. file-based routing
     ├── about.html
     └── index.html
 ```

--- a/app/docs/md/index.md
+++ b/app/docs/md/index.md
@@ -70,7 +70,7 @@ app
     └── index.html
 ```
 
-Add a [pure function](https://en.wikipedia.org/wiki/Pure_function) that returns an html string.
+Add a [pure function](https://en.wikipedia.org/wiki/Pure_function) that returns an HTML string.
 Your function will be passed an object containing an `html` render function for expanding custom elements.
 
 Add a `my-header.mjs` file in the `app/elements/` folder.

--- a/app/docs/md/learn/concepts/html/elements.md
+++ b/app/docs/md/learn/concepts/html/elements.md
@@ -6,7 +6,7 @@ Custom element expansion allows you to write [pure functions](https://en.wikiped
 
 ## Dependency free
 
-Enhance single file components are designed to be used without needing to import dependencies. Dependency free components means less unplanned work and fewer breaking changes.
+Enhance single-file components are designed to be used without needing to import dependencies. Dependency free components means less unplanned work and fewer breaking changes.
 
 ## Naming convention
 
@@ -15,7 +15,7 @@ In your Enhance project the names of the files in your project's `app/elements` 
 
 ## Expansion
 
-Write this single file component
+Write this single-file component
 
 ```javascript
 export default function MyHeader({ html, state }) {

--- a/app/docs/md/learn/concepts/html/index.md
+++ b/app/docs/md/learn/concepts/html/index.md
@@ -3,10 +3,10 @@ title: Rendering
 ---
 
 
-Enhance gives you the ability to write HTML pages comprised of custom elements authored as [single file components](/docs/learn/concepts/single-file-components) that get expanded on demand.
+Enhance gives you the ability to write HTML pages comprised of custom elements authored as [single-file components](/docs/learn/concepts/single-file-components) that get expanded on demand.
 
 ## Less tedium
-Single file components are rendered on the server where Enhance does the tedious work of expanding custom elements as well as setting up your document for progressively enhancing components for dynamic render in the browser.
+Single-file components are rendered on the server where Enhance does the tedious work of expanding custom elements as well as setting up your document for progressively enhancing components for dynamic render in the browser.
 
 ## Styles and scripts
 Enhance processes your style tags moving them to the head of the document and also moves any script tags in your component to the bottom of the document. This is done via [transforms](/docs/learn/features/transforms/) which are extension points you can add for your project if need be.
@@ -14,7 +14,7 @@ Enhance processes your style tags moving them to the head of the document and al
 ## Load faster
 Server side render is great for when you have mostly static content. Lots of components are not updated dynamically in the browser so Enhance dramatically cuts down on the JavaScript required for your app which speeds up page load significantly.
 
-## Standards based reuse
+## Standards-based reuse
 Repeated markup authored as custom elements enables reuse but Enhance also adds special handling of `<slot>` elements following the [Web Component standard](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#adding_flexibility_with_slots). This powerful feature enables you to reuse layouts and components by substituting their internals while maintaining core functionality.
 
 <doc-callout level="none" mark="✨">

--- a/app/docs/md/learn/concepts/html/index.md
+++ b/app/docs/md/learn/concepts/html/index.md
@@ -2,7 +2,6 @@
 title: Rendering
 ---
 
-
 Enhance gives you the ability to write HTML pages comprised of custom elements authored as [single-file components](/docs/learn/concepts/single-file-components) that get expanded on demand.
 
 ## Less tedium

--- a/app/docs/md/learn/concepts/routing/api-routes.md
+++ b/app/docs/md/learn/concepts/routing/api-routes.md
@@ -52,7 +52,7 @@ API routes always return a `response` object:
 
 ## Middleware
 
-API routes have a lightweight middleware concept. Export an array of async function handlers, and they will be run in the order you define. 
+API routes have a lightweight middleware concept. Export an array of async function handlers, and they will be run in the order you define.
 
 ```javascript
 export let get = [one, two]

--- a/app/docs/md/learn/concepts/routing/api-routes.md
+++ b/app/docs/md/learn/concepts/routing/api-routes.md
@@ -2,7 +2,7 @@
 title: API Routes
 ---
 
-Enhance API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`. JSON response values from API routes are automatically passed to corresponding page routes.
+Enhance's API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`. JSON response values from API routes are automatically passed to corresponding page routes.
 
 API routes are designed to handle requests made for `text/html`, or `application/json` from a single HTTP request handler. API routes by default should always export `get` and `post` handlers for working with HTML forms. API routes can also optionally export handlers for `put`, `patch`, and `destroy` for use with client-side JavaScript fetch.
 

--- a/app/docs/md/learn/concepts/routing/api-routes.md
+++ b/app/docs/md/learn/concepts/routing/api-routes.md
@@ -2,9 +2,9 @@
 title: API Routes
 ---
 
-Enhance API routes are backend JSON routes designed for seamless clientside progressive enhancement. API routes are defined under `app/api` and follow the same file based routing conventions as `app/pages`. JSON response values from API routes are automatically passed to corresponding page routes.
+Enhance API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`. JSON response values from API routes are automatically passed to corresponding page routes.
 
-API routes are designed to handle requests made for `text/html`, or `application/json` from a single HTTP request handler. API routes by default should always export `get` and `post` handlers for working with HTML forms. API routes can also optionally export handlers for `put`, `patch`, and `destroy` for use with clientside JavaScript fetch.
+API routes are designed to handle requests made for `text/html`, or `application/json` from a single HTTP request handler. API routes by default should always export `get` and `post` handlers for working with HTML forms. API routes can also optionally export handlers for `put`, `patch`, and `destroy` for use with client-side JavaScript fetch.
 
 ## Example
 

--- a/app/docs/md/learn/concepts/routing/index.md
+++ b/app/docs/md/learn/concepts/routing/index.md
@@ -2,7 +2,7 @@
 title: Enhance Routing
 ---
 
-Enhance uses a file-system based router. When a file is added to the `pages` or `api` directory, it's automatically available as a route.
+Enhance uses a filesystem-based router. When a file is added to the `pages` or `api` directory, it's automatically available as a route.
 
 <doc-callout level="none" mark="🌱">
 
@@ -43,7 +43,7 @@ app/pages/docs/$$.mjs → /docs/:path → eg. (/docs/concepts/styling/)
 
 ## API Routes
 
-Enhance API routes are backend JSON routes designed for seamless clientside progressive enhancement. API routes are defined under `app/api` and follow the same file based routing conventions as `app/pages`.
+Enhance API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`.
 
 <doc-code filename="api/index.mjs">
 

--- a/app/docs/md/learn/concepts/routing/index.md
+++ b/app/docs/md/learn/concepts/routing/index.md
@@ -43,7 +43,7 @@ app/pages/docs/$$.mjs → /docs/:path → eg. (/docs/concepts/styling/)
 
 ## API Routes
 
-Enhance API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`.
+Enhance's API routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`.
 
 <doc-code filename="api/index.mjs">
 

--- a/app/docs/md/learn/concepts/routing/lifecycle.md
+++ b/app/docs/md/learn/concepts/routing/lifecycle.md
@@ -49,7 +49,7 @@ my-rad-app.net/contact → app/pages/contact.[html|mjs]
 
 ### Custom Elements
 
-Pages are the main entry point and usually contain one or more of your app's [custom elements](/docs/learn/concepts/single-file-components).  
+Pages are the main entry point and usually contain one or more of your app's [custom elements](/docs/learn/concepts/single-file-components).
 Enhance will assemble the Page by recursively [expanding custom elements](/docs/learn/concepts/html/elements), using your single-file-components in the `app/elements/` directory.
 
 If there is no custom element definition in `app/elements/`, Enhance will render it as is and move on.
@@ -72,14 +72,14 @@ These `<script>`s are where you write the front end JavaScript to [progressively
 
 <doc-callout level="caution" mark="✨">
 
-The yellow areas in the above diagram represent the JavaScript that will be run in a browser.  
+The yellow areas in the above diagram represent the JavaScript that will be run in a browser.
 To create the best starting point for the browser, in the fastest way possible, the rest of your code is executed on the server.
 
 </doc-callout>
 
 ## Not Covered Here
 
-This lifecycle description demonstrates the real-time journey of a request through Enhance's web server.  
+This lifecycle description demonstrates the real-time journey of a request through Enhance's web server.
 It does not include static asset resolution (from `public/` via `_public/`), which has a separate lifecycle for even faster responses for non-dynamic content.
 <!-- TODO: create a "Public" doc under "Starter Project" with a diagram and link here 👆 -->
 

--- a/app/docs/md/learn/concepts/single-file-components.md
+++ b/app/docs/md/learn/concepts/single-file-components.md
@@ -6,9 +6,9 @@ links: # Further Reading
   - "Simon Willison's walk-through": https://til.simonwillison.net/web-components/understanding-single-file-web-component
 ---
 
-Every modern web framework has the concept of a component. Most require you to learn a non-standard dialect in order to use them though. Enhance enables you to write single file components with the same benefits of co-location and ease of reuse while leveraging the skills you already have.
+Every modern web framework has the concept of a component. Most require you to learn a non-standard dialect in order to use them though. Enhance enables you to write single-file components with the same benefits of co-location and ease of reuse while leveraging the skills you already have.
 
-Wouldn't it be nice if you could author components like HTML pages? Well that's what you get with Enhance single file components.
+Wouldn't it be nice if you could author components like HTML pages? Well that's what you get with Enhance single-file components.
 
 ## It's just HTML
 

--- a/app/docs/md/learn/concepts/state/store.md
+++ b/app/docs/md/learn/concepts/state/store.md
@@ -2,7 +2,7 @@
 title: Store
 ---
 
-The Enhance store is a single source of truth and how you get access to complex data types such as `Array` and `Object` inside your Custom Element [pure functions](https://en.wikipedia.org/wiki/Pure_function). This is needed because attributes can only be of type string. Enhance projects are also preconfigured to pass initial state from [api routes](/docs/learn/starter-project/api). This single source of truth is how you pass application data to your Custom Element pure functions.
+The Enhance store is a single source of truth and how you get access to complex data types such as `Array` and `Object` inside your Custom Element [pure functions](https://en.wikipedia.org/wiki/Pure_function). This is needed because attributes can only be of type string. Enhance projects are also preconfigured to pass initial state from [API routes](/docs/learn/starter-project/api). This single source of truth is how you pass application data to your Custom Element pure functions.
 
 ## Access `store`
 

--- a/app/docs/md/learn/concepts/styling/element-styles.md
+++ b/app/docs/md/learn/concepts/styling/element-styles.md
@@ -6,7 +6,7 @@ Element styles are for specific styles that can't easily be achieved with utilit
 
 ## Element Pseudo classes
 
-Enhance projects come preconfigured with a styling system that let's you use pseudo classes like `:host` and `::slotted()`.
+Enhance projects come preconfigured with a styling system that lets you use pseudo classes like `:host` and `::slotted()`.
 These pseudo classes give you the ability to style the outer Custom Element tag as well as slotted elements.
 This enables you to write scoped styles co-located inside your single file component.
 

--- a/app/docs/md/learn/concepts/styling/element-styles.md
+++ b/app/docs/md/learn/concepts/styling/element-styles.md
@@ -8,7 +8,7 @@ Element styles are for specific styles that can't easily be achieved with utilit
 
 Enhance projects come preconfigured with a styling system that lets you use pseudo classes like `:host` and `::slotted()`.
 These pseudo classes give you the ability to style the outer Custom Element tag as well as slotted elements.
-This enables you to write scoped styles co-located inside your single file component.
+This enables you to write scoped styles co-located inside your single-file component.
 
 ```html
 <style>

--- a/app/docs/md/learn/concepts/styling/index.md
+++ b/app/docs/md/learn/concepts/styling/index.md
@@ -10,13 +10,13 @@ There are a lot of solutions for approaching CSS, but very few that are designed
 Enhance projects are set up in a way to enable developers to add styles without compromising user experience via slow load times or flash of unstyled content.
 This is done by returning to first principles and thinking about what a developer could do by hand that would be both optimal and specific.
 
-Enhance [single-file components](/docs/learn/concepts/single-file-components) allow you to co-locate your styles (using `<style>` tags) with your markup. 
-Enhance projects also come preconfigured with [a customizable utility class system](/docs/learn/concepts/styling/utility-classes).  
+Enhance [single-file components](/docs/learn/concepts/single-file-components) allow you to co-locate your styles (using `<style>` tags) with your markup.
+Enhance projects also come preconfigured with [a customizable utility class system](/docs/learn/concepts/styling/utility-classes).
 This enables you to reuse utility classes without bloating your stylesheets for general styling while also use element styling for specific CSS that utility classes are not designed for.
 
 ## Utility classes
 
-A quick look at applying utility classes.  
+A quick look at applying utility classes.
 These classes are general and adhere to a system.
 
 ```javascript

--- a/app/docs/md/learn/concepts/styling/index.md
+++ b/app/docs/md/learn/concepts/styling/index.md
@@ -12,7 +12,7 @@ This is done by returning to first principles and thinking about what a develope
 
 Enhance [single-file components](/docs/learn/concepts/single-file-components) allow you to co-locate your styles (using `<style>` tags) with your markup. 
 Enhance projects also come preconfigured with [a customizable utility class system](/docs/learn/concepts/styling/utility-classes).  
-This enables you to reuse utility classes without bloating your stylesheets for general styling while also use element styling for specific css that utility classes are not designed for.
+This enables you to reuse utility classes without bloating your stylesheets for general styling while also use element styling for specific CSS that utility classes are not designed for.
 
 ## Utility classes
 

--- a/app/docs/md/learn/concepts/styling/index.md
+++ b/app/docs/md/learn/concepts/styling/index.md
@@ -7,10 +7,10 @@ There are a lot of solutions for approaching CSS, but very few that are designed
 
 ## Optimal styling
 
-Enhance projects are set-up in a way to enable developers to add styles without compromising user experience via slow load times or flash of unstyled content.
+Enhance projects are set up in a way to enable developers to add styles without compromising user experience via slow load times or flash of unstyled content.
 This is done by returning to first principles and thinking about what a developer could do by hand that would be both optimal and specific.
 
-Enhance [single file components](/docs/learn/concepts/single-file-components) allow you to co-locate your styles (using `<style>` tags) with your markup. 
+Enhance [single-file components](/docs/learn/concepts/single-file-components) allow you to co-locate your styles (using `<style>` tags) with your markup. 
 Enhance projects also come preconfigured with [a customizable utility class system](/docs/learn/concepts/styling/utility-classes).  
 This enables you to reuse utility classes without bloating your stylesheets for general styling while also use element styling for specific css that utility classes are not designed for.
 

--- a/app/docs/md/learn/deployment/11ty.md
+++ b/app/docs/md/learn/deployment/11ty.md
@@ -49,7 +49,7 @@ Create `index.html`, and write some HTML!
 
 ```html
 <my-header></my-header>
-<strong>powerful html here</strong>
+<strong>powerful HTML here</strong>
 <my-footer></my-footer>
 ```
 

--- a/app/docs/md/learn/deployment/architect.md
+++ b/app/docs/md/learn/deployment/architect.md
@@ -6,7 +6,7 @@ Architect deploys Function Web Apps ([FWA](https://fwa.dev)) that are dynamic we
 
 ## Quickstart
 
-Install the Architect CLI with npm: `npm i -g @architect/architect`. 
+Install the Architect CLI with npm: `npm i -g @architect/architect`.
 
 > 🔬 [Detailed instructions for setting up your AWS credentials.](https://arc.codes/docs/en/get-started/detailed-aws-setup)
 

--- a/app/docs/md/learn/deployment/fastify.md
+++ b/app/docs/md/learn/deployment/fastify.md
@@ -2,7 +2,7 @@
 title: Fastify
 ---
 
-Fastify is a very fast, beautifully designed, and well maintained app server for Node. `@enhance/fastify-plugin` gives you the ability to build your frontend completely in HTML, and pure custom elements. 
+Fastify is a very fast, beautifully designed, and well maintained app server for Node. `@enhance/fastify-plugin` gives you the ability to build your frontend completely in HTML, and pure custom elements.
 
 Fastify can be deployed to any cloud vendor that supports deploying a Node web server; the most popular choices are [AWS](https://aws.amazon.com/getting-started/hands-on/deploy-nodejs-web-app/), [Azure](https://docs.microsoft.com/en-us/azure/app-service/quickstart-nodejs?tabs=linux&pivots=development-environment-vscode), and [GCP](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-nodejs-service).
 
@@ -11,7 +11,7 @@ Fastify can be deployed to any cloud vendor that supports deploying a Node web s
 Create a project.
 
 ```bash
-mkdir -p myproject 
+mkdir -p myproject
 cd myproject
 npm init -y
 npm install fastify @enhance/fastify-plugin
@@ -130,7 +130,7 @@ Add `/fruits` by creating `app/pages/fruits.mjs`:
 export default function fruits ({ html, state }) {
   let fruit = f => `<li>${f}</li>`
   let list = state.store.fruits
-    ? state.store.fruits.map(fruit).join('') 
+    ? state.store.fruits.map(fruit).join('')
     : []
   
   return html`

--- a/app/docs/md/learn/deployment/fastify.md
+++ b/app/docs/md/learn/deployment/fastify.md
@@ -51,7 +51,7 @@ Create `app/pages/index.html`, and write some HTML!
 
 ```html
 <my-header></my-header>
-<strong>powerful html here</strong>
+<strong>powerful HTML here</strong>
 <my-footer></my-footer>
 ```
 

--- a/app/docs/md/learn/features/transforms/index.md
+++ b/app/docs/md/learn/features/transforms/index.md
@@ -2,4 +2,4 @@
 title: Transforms
 ---
 
-Single file components allow for collocating component markup, styles, and behavior scripts together. But to optimize page performance scripts and styles need to be relocated and transformed. 
+Single-file components allow for collocating component markup, styles, and behavior scripts together. But to optimize page performance scripts and styles need to be relocated and transformed. 

--- a/app/docs/md/learn/features/transforms/index.md
+++ b/app/docs/md/learn/features/transforms/index.md
@@ -2,4 +2,4 @@
 title: Transforms
 ---
 
-Single-file components allow for collocating component markup, styles, and behavior scripts together. But to optimize page performance scripts and styles need to be relocated and transformed. 
+Single-file components allow for collocating component markup, styles, and behavior scripts together. But to optimize page performance scripts and styles need to be relocated and transformed.

--- a/app/docs/md/learn/features/transforms/script-transforms.md
+++ b/app/docs/md/learn/features/transforms/script-transforms.md
@@ -2,7 +2,7 @@
 title: Script Transforms
 ---
 
-Single file components co-locate scripts  with your Custom Element output for progressive enhancement. All the scripts are collected and moved to the end of the body during render. Enhance supports transform plugins for processing the contents of these scripts if needed.
+Single-file components co-locate scripts  with your Custom Element output for progressive enhancement. All the scripts are collected and moved to the end of the body during render. Enhance supports transform plugins for processing the contents of these scripts if needed.
 
 ## Basic Usage
 

--- a/app/docs/md/learn/features/transforms/style-transforms.md
+++ b/app/docs/md/learn/features/transforms/style-transforms.md
@@ -24,7 +24,6 @@ Style Transforms are passed as an array. They are called with a single object ar
 
 The return value from the transform is the new string contents of the style tag.
 
-
 ## Basic Usage
 This style transform is an example for deploying to [arc.codes](arc.codes).
 
@@ -156,5 +155,3 @@ This approach doesn't completely avoid unintentional deep selection of nested el
 - Use specific selectors to avoid deep selecting.
   It is better to use the `>` child selector rather than the general descendent selector when possible(i.e. `:host > div` ).
 - With slotted and part be specific enough to avoid over selection
-
-

--- a/app/docs/md/learn/practices/architect-migration.md
+++ b/app/docs/md/learn/practices/architect-migration.md
@@ -4,10 +4,10 @@ links:
   - "arc.codes": https://arc.codes
 ---
 
-Enhance uses [Architect](https://arc.codes) under the hood for local development and deployment. It is possible to migrate between a typical Architect project structure and the Enhance file based routing. It is also possible to mix the two approaches together in the same app. They are incrementally adoptable in both directions.
+Enhance uses [Architect](https://arc.codes) under the hood for local development and deployment. It is possible to migrate between a typical Architect project structure and the Enhance file-based routing. It is also possible to mix the two approaches together in the same app. They are incrementally adoptable in both directions.
 
 ## How are they different
-Enhance uses file based routing so that a route handler responds based on its file name and the folder it is in. Architect apps use the .arc manifest folder to specify the connection between route and handler.
+Enhance uses file-based routing so that a route handler responds based on its file name and the folder it is in. Architect apps use the .arc manifest folder to specify the connection between route and handler.
 
 Enhance project routes are in effect an Architect route handler with the data API and HTML response split into two files. Enhance also includes the Enhance SSR renderer for expanding Custom Elements on the server.
 
@@ -140,7 +140,7 @@ get /books
 
 5. Move each handler into the file base routing `app/api` and `app/pages` folders and then remove the corresponding route definition in the arc file.
 
-A route that is defined in both the @http pragma and the file based routing will be handled by the @http handler. Do not remove all @http routes until after the plugin has been added. This could result in the address for the deployed app changing which would break the DNS settings for the app.
+A route that is defined in both the @http pragma and the file-based routing will be handled by the @http handler. Do not remove all @http routes until after the plugin has been added. This could result in the address for the deployed app changing which would break the DNS settings for the app.
 
 <doc-code filename="app.arc" highlight="7:9-delete">
 
@@ -160,13 +160,13 @@ get /books
 
 ## Caveats
 
-- Enhance takes over the root catchall. Enhance uses `get /*` for its file based routing. If you combine both Architect routes with Enhance routes you cannot define a new root catchall in the .arc manifest or none of the Enhance routes will work.
+- Enhance takes over the root catchall. Enhance uses `get /*` for its file-based routing. If you combine both Architect routes with Enhance routes you cannot define a new root catchall in the .arc manifest or none of the Enhance routes will work.
 - If you remove all @http routes before adding the enhance plugin the app DNS address will be released and DNS setting will need to be updated.
 - Begin data is included in the Enhance plugin. It may cause problems and potential data loss if the enhance plugin is added to an app that is already using begin data. Backup all data to avoid critical data loss.
 
 ## Which is better?
 
-There are reasons to choose either. There is no need to convert or transition a working app from one to the other. Both approaches will be maintained and updated moving forward. That being said many developers will likely find it extremely fast and convenient to start a greenfield project with Enhances file based routing.
+There are reasons to choose either. There is no need to convert or transition a working app from one to the other. Both approaches will be maintained and updated moving forward. That being said many developers will likely find it extremely fast and convenient to start a greenfield project with Enhances file-based routing.
 
 If you have an existing app that you want to use Enhances SSR with it you can add the enhance-ssr package inside any route handler.
 

--- a/app/docs/md/learn/practices/architect-migration.md
+++ b/app/docs/md/learn/practices/architect-migration.md
@@ -166,7 +166,7 @@ get /books
 
 ## Which is better?
 
-There are reasons to chose either. There is no need to convert or transition a working app from one to the other. Both approaches will be maintained and updated moving forward. That being said many developers will likely find it extremely fast and convenient to start a greenfield project with Enhances file based routing.
+There are reasons to choose either. There is no need to convert or transition a working app from one to the other. Both approaches will be maintained and updated moving forward. That being said many developers will likely find it extremely fast and convenient to start a greenfield project with Enhances file based routing.
 
 If you have an existing app that you want to use Enhances SSR with it you can add the enhance-ssr package inside any route handler.
 

--- a/app/docs/md/learn/practices/architect-migration.md
+++ b/app/docs/md/learn/practices/architect-migration.md
@@ -157,18 +157,16 @@ get /books
 ```
 </doc-code>
 
-
 ## Caveats
 
 - Enhance takes over the root catchall. Enhance uses `get /*` for its file-based routing. If you combine both Architect routes with Enhance routes you cannot define a new root catchall in the .arc manifest or none of the Enhance routes will work.
-- If you remove all @http routes before adding the enhance plugin the app DNS address will be released and DNS setting will need to be updated.
+- If you remove all @http routes before adding the enhance plugin, the app DNS address will be released and DNS setting will need to be updated.
 - Begin data is included in the Enhance plugin. It may cause problems and potential data loss if the enhance plugin is added to an app that is already using begin data. Backup all data to avoid critical data loss.
 
 ## Which is better?
 
 There are reasons to choose either. There is no need to convert or transition a working app from one to the other. Both approaches will be maintained and updated moving forward. That being said many developers will likely find it extremely fast and convenient to start a greenfield project with Enhances file-based routing.
 
-If you have an existing app that you want to use Enhances SSR with it you can add the enhance-ssr package inside any route handler.
+If you have an existing app that you want to use Enhances SSR with, you can add the `enhance-ssr` package inside any route handler.
 
 Even if you start with Enhances project structure to take advantage of many of the DX improvements as your app grows there will likely come a time when one route grows large or needs to be customized in some way. At that point the best option is to create an Architect style handler for just that route out.
-

--- a/app/docs/md/learn/practices/architect-migration.md
+++ b/app/docs/md/learn/practices/architect-migration.md
@@ -14,8 +14,6 @@ Enhance project routes are in effect an Architect route handler with the data AP
 ## Shared code (shared, views, models, and app)
 If you are familiar with Architect apps they use the convention of a `src/views` and `src/shared` folder to share code between handlers. View code is available only to `GET` routes and shared is available to all handlers. Enhance renames these folders so that views becomes `/app` and shared becomes `/models`.
 
-
-
 ## Convert routes from Architect and Enhance
 An Architect route is defined in the `app.arc` manifest.
 

--- a/app/docs/md/learn/practices/browser-modules.md
+++ b/app/docs/md/learn/practices/browser-modules.md
@@ -5,13 +5,13 @@ title: Browser Modules
 <doc-callout level="info" mark="🧺">
 
 Enhance projects let you share modules with the browser via ***"bundles"***.
-Using the built in bundling system serves code via your own domain instead of from a third-party registry.  
+Using the built in bundling system serves code via your own domain instead of from a third-party registry.
 No need to fuss over CORS or external downtime.
 
 </doc-callout>
 
 Under the hood, the Enhance Starter Project uses the [Architect](https://arc.codes) framework.
-Architect projects have a manifest file: `.arc`.  
+Architect projects have a manifest file: `.arc`.
 To bundle code for the browser, simply add an entry to your `.arc` file.
 Set the **name** and **path** under the `@bundles` setting (called "pragmas").
 
@@ -93,7 +93,6 @@ These classes can now be imported as needed.
 import { TodoList, TodoItem } from '/_public/bundles/todos.mjs'
 ```
 
-
 ## Bundling External Modules
 
 You may want to install an external dependency for use in the browser.
@@ -161,7 +160,7 @@ customElements.define("todo-item", TodoItem);
 
 </doc-code>
 
-This example doesn't do a whole lot yet, but it's a good starting place.  
+This example doesn't do a whole lot yet, but it's a good starting place.
 To have our `todo-item.ts` transpiled and served to our front end, just give it a name and a path in the project's `.arc` file:
 
 ```arc

--- a/app/docs/md/learn/practices/env-vars.md
+++ b/app/docs/md/learn/practices/env-vars.md
@@ -2,10 +2,10 @@
 title: Environment Variables
 ---
 
-It is a good practice to store runtime configuration data, such as API keys, in environment variables. When working locally Enhance supports loading environment variables ith a `.env` file. 
+It is a good practice to store runtime configuration data, such as API keys, in environment variables. When working locally Enhance supports loading environment variables ith a `.env` file.
 
 <doc-callout mark="🔎">
-To provision environment variables for production deployment please consult the documentation for the different deployment providers. 
+To provision environment variables for production deployment please consult the documentation for the different deployment providers.
 </doc-callout>
 
 ## Local Dev Environment Variable Tutorial
@@ -34,8 +34,8 @@ API Routes are a Node.js process; `process.env` lists all environment variables.
 ```javascript
 export async function get () {
   const env = process.env
-  return { 
-    json: { env } 
+  return {
+    json: { env }
   }
 }
 ```
@@ -51,7 +51,7 @@ Display the values passed from the API Route.
 ```javascript
 export default async function debug ({ html, state }) {
   const env = state.store?.env
-  return html`<pre>${ env }</pre>` 
+  return html`<pre>${ env }</pre>`
 }
 ```
 

--- a/app/docs/md/learn/practices/env-vars.md
+++ b/app/docs/md/learn/practices/env-vars.md
@@ -10,7 +10,7 @@ To provision environment variables for production deployment please consult the 
 
 ## Local Dev Environment Variable Tutorial
 
-In this walkthrough we will setup environment variables, and display them on an example debug page. Please note, a `.env` file *should not* be checked-in to revision control because it will often contain sensitive information. Environment variables normally should never be leaked, or displayed to the end web consumer: this is an example to help demonstrate the lifecycle.
+In this walkthrough we will set up environment variables, and display them on an example debug page. Please note, a `.env` file *should not* be checked-in to revision control because it will often contain sensitive information. Environment variables normally should never be leaked, or displayed to the end web consumer: this is an example to help demonstrate the lifecycle.
 
 ### 1. Create a `.env` file
 

--- a/app/docs/md/learn/practices/env-vars.md
+++ b/app/docs/md/learn/practices/env-vars.md
@@ -10,7 +10,7 @@ To provision environment variables for production deployment please consult the 
 
 ## Local Dev Environment Variable Tutorial
 
-In this walkthrough we will setup environment variables, and display them on an example debug page. Please note, an `.env` file *should not* be checked-in to revision control because it will often contain sensitive information. Environment variables normally should never be leaked, or displayed to the end web consumer: this is an example to help demonstrate the lifecycle.
+In this walkthrough we will setup environment variables, and display them on an example debug page. Please note, a `.env` file *should not* be checked-in to revision control because it will often contain sensitive information. Environment variables normally should never be leaked, or displayed to the end web consumer: this is an example to help demonstrate the lifecycle.
 
 ### 1. Create a `.env` file
 

--- a/app/docs/md/learn/practices/progressive-enhancement.md
+++ b/app/docs/md/learn/practices/progressive-enhancement.md
@@ -24,7 +24,7 @@ Author this HTML
 <my-message message="Progressive"></my-message>
 ```
 
-Create this single file component
+Create this single-file component
 
 <doc-code filename="app/elements/my-message.mjs" numbered>
 
@@ -70,11 +70,11 @@ With scoped DOM queries and low level DOM apis you can perform optimal surgical 
 
 ## Externalize scripts
 
-If your script outgrows your single file component you can link to it. Another way you can incrementally progress your elements to support your needs.
+If your script outgrows your single-file component you can link to it. Another way you can incrementally progress your elements to support your needs.
 
 Move your script to the `/public` folder
 
-Create this single file component
+Create this single-file component
 
 <doc-code highlight="7-add" filename="app/elements/my-message.mjs" numbered>
 

--- a/app/docs/md/learn/starter-project/404-errors.md
+++ b/app/docs/md/learn/starter-project/404-errors.md
@@ -2,7 +2,7 @@
 title: '404 and 500 Error Pages'
 ---
 
-Errors happen. You can add custom pages to respond to 404 and 500 type errors by adding a `404.html` or `404.mjs`, and `500.html` or `500.mjs` files to the `/pages` directory. If no user-defined pages are found enhance will respond with a basic error message. 
+Errors happen. You can add custom pages to respond to 404 and 500 type errors by adding a `404.html` or `404.mjs`, and `500.html` or `500.mjs` files to the `/pages` directory. If no user-defined pages are found enhance will respond with a basic error message.
 
 If there is a relevant error message it is added as an attribute passed to the state of the 404.mjs. The function signature is the same as any other component including the `html` function and the initial state as `state`. The `state` property will be undefined.
 

--- a/app/docs/md/learn/starter-project/api.md
+++ b/app/docs/md/learn/starter-project/api.md
@@ -13,7 +13,7 @@ Create an `api` route that passes data to your `index.html` page.
 app
 ├── api ............... data routes
 │   └── index.mjs
-└── pages ............. file based routing
+└── pages ............. file-based routing
     └── index.html
 ```
 
@@ -47,7 +47,7 @@ app
 │   └── index.mjs
 ├── elements .......... custom element pure functions
 │   └── my-message.mjs
-└── pages ............. file based routing
+└── pages ............. file-based routing
     └── index.html
 ```
 

--- a/app/docs/md/learn/starter-project/elements.md
+++ b/app/docs/md/learn/starter-project/elements.md
@@ -2,7 +2,7 @@
 title: Elements
 ---
 
-Elements are the reusable building blocks of your Enhance application. They are [pure functions](https://en.wikipedia.org/wiki/Pure_function) authored as single file components and can be static or update dynamically to state changes. Elements live in the `app/elements/` folder in the Enhance starter project.
+Elements are the reusable building blocks of your Enhance application. They are [pure functions](https://en.wikipedia.org/wiki/Pure_function) authored as single-file components and can be static or update dynamically to state changes. Elements live in the `app/elements/` folder in the Enhance starter project.
 
 ## Naming
 
@@ -23,7 +23,7 @@ app/elements/blog/comment-form → <blog-comment-form></blog-comment-form>
 
 <doc-callout level="none" mark="📄">
 
-**[Learn about single file components](/docs/learn/concepts/single-file-components)**
+**[Learn about single-file components](/docs/learn/concepts/single-file-components)**
 
 </doc-callout>
 

--- a/app/docs/md/learn/starter-project/elements.md
+++ b/app/docs/md/learn/starter-project/elements.md
@@ -61,5 +61,3 @@ export default function MyHeader({ html, state }) {
   `
 }
 ```
-
-

--- a/app/docs/md/learn/starter-project/head.md
+++ b/app/docs/md/learn/starter-project/head.md
@@ -88,7 +88,6 @@ export default function TwitterMeta(state) {
 
 </doc-code>
 
-
 You can then use this meta content template in your `head.mjs` like so:
 
 <doc-code filename="/app/head.mjs">

--- a/app/docs/md/learn/starter-project/pages.md
+++ b/app/docs/md/learn/starter-project/pages.md
@@ -4,9 +4,9 @@ title: Pages
 
 Pages are the entry point for Enhance rendering. They are authored in standard HTML, and the output is setup for progressive enhancement with custom elements in the browser. Pages live in the `app/pages/` folder of the Enhance starter project.
 
-## File based routing
+## File-based routing
 
-Pages in the Enhance starter project enable file based routing. Meaning that adding a `app/pages/about.html` for instance will make it available at `/about` in your browser.
+Pages in the Enhance starter project enable file-based routing. Meaning that adding a `app/pages/about.html` for instance will make it available at `/about` in your browser.
 
 ```
 app/pages/index.html → https://yoursite.com/
@@ -19,11 +19,11 @@ Pages are written in HTML and can be composed of many dynamic custom elements. P
 
 ## Dynamic if need be
 
-Pages can also be written as single file components that get passed state but we recommend handling state in Elements to cut down on unnecessary complexity.
+Pages can also be written as single-file components that get passed state but we recommend handling state in Elements to cut down on unnecessary complexity.
 
 <doc-callout level="none" mark="🙌">
 
-**[Read about single file components here](/docs/learn/concepts/single-file-components)**
+**[Read about single-file components here](/docs/learn/concepts/single-file-components)**
 
 </doc-callout>
 

--- a/app/docs/md/learn/starter-project/public.md
+++ b/app/docs/md/learn/starter-project/public.md
@@ -48,7 +48,7 @@ Given the structure above, your application can include assets from the `/_publi
 <doc-callout level="info" mark="🧬">
 
 File "fingerprinting" is giving static files a unique filename based on that file's contents.
-Typically this uses a computational hash of that file's content as part of the name.  
+Typically this uses a computational hash of that file's content as part of the name.
 `logo.png` becomes `logo-cd94b3594d.png`.
 
 </doc-callout>
@@ -90,7 +90,7 @@ The `/_public` route does not provide any sort of concatenation or compilation o
 However, it does play nicely with another Enhance feature: the `@bundles` pragma.
 
 <doc-link-callout link="/docs/learn/practices/browser-modules" mark="🧺">
-  
+
 Learn about bundling browser modules (JS, CSS, + TS) with `@bundles`
 
 </doc-link-callout>

--- a/app/docs/md/learn/starter-project/structure.md
+++ b/app/docs/md/learn/starter-project/structure.md
@@ -43,5 +43,3 @@ The `api` folder is preconfigured to expose data to your file-based routes. Mean
 **[Read more about `api` routes here →](/docs/learn/starter-project/api)**
 
 </doc-callout>
-
-

--- a/app/docs/md/learn/starter-project/structure.md
+++ b/app/docs/md/learn/starter-project/structure.md
@@ -2,7 +2,7 @@
 title: Structure
 ---
 
-The Enhance starter project is set-up to enable you to create dynamic multi-page applications with as little friction as possible. It comes preconfigured with everything you need to work with file based routing and standards based components.
+The Enhance starter project is set up to enable you to create dynamic multi-page applications with as little friction as possible. It comes preconfigured with everything you need to work with file-based routing and standards-based components.
 
 ```
 app
@@ -10,12 +10,12 @@ app
 │   └── index.mjs
 ├── elements .......... custom element pure functions
 │   └── my-header.mjs
-└── pages ............. file based routing
+└── pages ............. file-based routing
     └── index.html
 ```
 
 ## Pages
-The pages folder enables file based routing. To add a route just add an HTML file. The name of the file will be the URL you view it at. Meaning `app/pages/about.html` will be viewed at `/about`.
+The pages folder enables file-based routing. To add a route just add an HTML file. The name of the file will be the URL you view it at. Meaning `app/pages/about.html` will be viewed at `/about`.
 
 <doc-callout level="none" mark="📃">
 
@@ -24,7 +24,7 @@ The pages folder enables file based routing. To add a route just add an HTML fil
 </doc-callout>
 
 ## Elements
-The elements folder is where you keep your [single file components](/docs/learn/concepts/single-file-components). These are custom element templates that get rendered server side and set-up your HTML page for progressive enhancement.
+The elements folder is where you keep your [single-file components](/docs/learn/concepts/single-file-components). These are custom element templates that get rendered server side and set-up your HTML page for progressive enhancement.
 
 Elements must be [named](https://html.spec.whatwg.org/multipage/custom-elements.html#prod-potentialcustomelementname) with one or more words separated by a dash `my-header.mjs` which corresponds to the tag name you author in your html pages `<my-header></my-header>`.
 
@@ -36,7 +36,7 @@ Elements must be [named](https://html.spec.whatwg.org/multipage/custom-elements.
 
 ## API
 
-The `api` folder is preconfigured to expose data to your file based routes. Meaning the file `app/api/index.mjs` will automatically pass state to `app/pages/index.mjs` as well as expose an endpoint for standard REST verbs like `get` and `post`
+The `api` folder is preconfigured to expose data to your file-based routes. Meaning the file `app/api/index.mjs` will automatically pass state to `app/pages/index.mjs` as well as expose an endpoint for standard REST verbs like `get` and `post`
 
 <doc-callout level="none" mark="🪄">
 

--- a/app/docs/md/learn/starter-project/structure.md
+++ b/app/docs/md/learn/starter-project/structure.md
@@ -26,7 +26,7 @@ The pages folder enables file-based routing. To add a route just add an HTML fil
 ## Elements
 The elements folder is where you keep your [single-file components](/docs/learn/concepts/single-file-components). These are custom element templates that get rendered server side and set-up your HTML page for progressive enhancement.
 
-Elements must be [named](https://html.spec.whatwg.org/multipage/custom-elements.html#prod-potentialcustomelementname) with one or more words separated by a dash `my-header.mjs` which corresponds to the tag name you author in your html pages `<my-header></my-header>`.
+Elements must be [named](https://html.spec.whatwg.org/multipage/custom-elements.html#prod-potentialcustomelementname) with one or more words separated by a dash `my-header.mjs` which corresponds to the tag name you author in your HTML pages `<my-header></my-header>`.
 
 <doc-callout level="none" mark="🔥">
 

--- a/app/docs/md/learn/why-enhance.md
+++ b/app/docs/md/learn/why-enhance.md
@@ -4,9 +4,9 @@ title: Why Enhance?
 
 Our mission is to enable anyone to build multi-page dynamic web apps while staying as close to the platform as possible. Enhance fills in the gaps to make building for the backend, and the browser a seamless experience for web authors and consumers.
 
-Modern JavaScript frameworks bring more problems than they solve; recreating native web platform features adding unnecessary weight and complexity, which is challenging to unravel. 
+Modern JavaScript frameworks bring more problems than they solve; recreating native web platform features adding unnecessary weight and complexity, which is challenging to unravel.
 
-Enhance provides a dependable foundation built on standards-based web platform features, allowing developers to create web applications that are lightweight, flexible, and future-proof. 
+Enhance provides a dependable foundation built on standards-based web platform features, allowing developers to create web applications that are lightweight, flexible, and future-proof.
 
 Our criteria for success are:
 
@@ -17,7 +17,6 @@ Our criteria for success are:
 **Enhance** should allow developers to write components as pure functions that return HTML. Then render them on the server to deliver complete HTML immediately available to the end user.
 
 </doc-callout>
-
 
 2. Use Web Standards
 
@@ -41,5 +40,3 @@ With direct access to all available browser APIs (like forms, validation, and st
 Skeleton screens and spinners be gone. Flashes of unstyled content (FOUC) or layout shifts from delayed JavaScript don't belong anymore.
 
 Using just HTML, CSS, and a sprinkling of JavaScript, Enhance can build complex dynamic applications in harmony with the Web Platform, allowing developers to spend their time on interesting domain problems leading to more engaging products with less thrash.
-
-

--- a/app/docs/md/reference/libraries/enhance-style-transform.md
+++ b/app/docs/md/reference/libraries/enhance-style-transform.md
@@ -4,25 +4,25 @@ links:
   - enhance-style-transform: https://github.com/enhance-dev/enhance-style-transform
 ---
 
-This transform enables scoping styles in Enhance components with or without the need for shadowDOM. 
+This transform enables scoping styles in Enhance components with or without the need for shadowDOM.
 
 It does not add new syntax. It sets firm upper bound so component styles can't bleed outside the component. It also allows some Web Component CSS selectors (::part, ::slotted, and :host) to target enhance components both before and after JavaScript hydrates the components. For server side rendering these selectors are converted to CSS that does not require the shadowDOM.
 
-## Goal 
+## Goal
 The shadowDOM gives full encapsulation of styles, but breaks other things like forms. When building with components what we want is some reasonable tools to help scope styles to those components. More like caution tape than chain-link fence. If the shadowDOM is used styles can be written once that will work before and after the shadowDOM initializes.
 
 ## limitations
-This approach doesn't completely avoid deep selection of nested elements. It makes tradeoffs to improve scoping without creating other problems. Transformed shadow selectors can also select some unintended elements if they are written to too broadly (i.e. `::slotted(*)` will select all children). If you prefer a bullet-proof style encapsulation and are willing to accept the downsides (broken forms, FOUC, etc.) use the shadowDOM.   
+This approach doesn't completely avoid deep selection of nested elements. It makes tradeoffs to improve scoping without creating other problems. Transformed shadow selectors can also select some unintended elements if they are written to too broadly (i.e. `::slotted(*)` will select all children). If you prefer a bullet-proof style encapsulation and are willing to accept the downsides (broken forms, FOUC, etc.) use the shadowDOM.
+
 ## Other Recommendations
 - Use with utility classes.
   This transform works well with utility class styles. We recommend writing most styles as utility classes directly on the elements in your template. This only leaves styles that cannot be written as utility classes which can be added to the component.
 - Use specific selectors to avoid deep selecting.
-  It is better to use the `>` child selector rather than the general descendant selector when possible(i.e. `:host > div` ). 
+  It is better to use the `>` child selector rather than the general descendant selector when possible(i.e. `:host > div` ).
 - With slotted and part be specific enough to avoid over selection
-  
 
 ## Basic Usage
-Below is an example a style transform when deploying to [arc.codes](arc.codes). 
+Below is an example a style transform when deploying to [arc.codes](arc.codes).
 
 ### Input
 ```JavaScript
@@ -86,10 +86,10 @@ export default function MyTag({html}){
 ## SSR transformations
 The transformations below are used for the server rendered styles. These styles will be collected and placed in the document head. The 'template' context styles do not receive any transformation.
 ### Component scoping
-Basic component scoping is done by adding a component selector to every rule. This effectively sets the upper bound to all rules so styles cannot leak outside the component. The rule `div {background: red}` becomes `my-tag div {background: red}`. This sets a firm upper bound on styles but it does not limit deep selecting for anything nested inside the component. This is sometimes useful and sometimes a problem. To limit deep selection you can use more specificity in your selector choice. Combining this technique with utility classes also helps limit deep selection by minimizing the number of rules that need to be written for each component. 
+Basic component scoping is done by adding a component selector to every rule. This effectively sets the upper bound to all rules so styles cannot leak outside the component. The rule `div {background: red}` becomes `my-tag div {background: red}`. This sets a firm upper bound on styles but it does not limit deep selecting for anything nested inside the component. This is sometimes useful and sometimes a problem. To limit deep selection you can use more specificity in your selector choice. Combining this technique with utility classes also helps limit deep selection by minimizing the number of rules that need to be written for each component.
 
-#### `:host` `:host()` `:host-context()` 
-When writing components it is often necessary to add styles to the element itself. The `:host` selector and its variations solve this problem, but they do not work when there is no shadowDOM. For the SSR context these styles are converted so that they work for both. `:host` itself is a selector stand in for the element. The function form of `:host()` is [required](https://drafts.csswg.org/css-scoping/#host-selector:~:text=it%20takes%20a%20selector%20argument%20for%20syntactic%20reasons%20(we%20can%E2%80%99t%20say%20that%20%3Ahost.foo%20matches%20but%20.foo%20doesn%E2%80%99t)%2C%20but%20is%20otherwise%20identical%20to%20just%20using%20%3Ahost%20followed%20by%20a%20selector.) to specify a class or attribute on the host itself. In order to select the context outside of host you can use the `:host-context()` form. 
+#### `:host` `:host()` `:host-context()`
+When writing components it is often necessary to add styles to the element itself. The `:host` selector and its variations solve this problem, but they do not work when there is no shadowDOM. For the SSR context these styles are converted so that they work for both. `:host` itself is a selector stand in for the element. The function form of `:host()` is [required](https://drafts.csswg.org/css-scoping/#host-selector:~:text=it%20takes%20a%20selector%20argument%20for%20syntactic%20reasons%20(we%20can%E2%80%99t%20say%20that%20%3Ahost.foo%20matches%20but%20.foo%20doesn%E2%80%99t)%2C%20but%20is%20otherwise%20identical%20to%20just%20using%20%3Ahost%20followed%20by%20a%20selector.) to specify a class or attribute on the host itself. In order to select the context outside of host you can use the `:host-context()` form.
 
 ```CSS
 /* Scoping without host */
@@ -112,13 +112,13 @@ footer > h1 my-tag div { color: red; }
 
 ```
 
-#### `::slotted()` 
-With shadowDOM `<slot>`'s child elements in the light DOM are rendered inside the shadowDOM. The `::slotted()` pseudo selector is used inside the shadowDOM to style these elements. Any selector argument will be applied to any matching elements that are slotted. The transform takes rules like `div::slotted([slot=here]) { color:red; }` and returns `div[slot=here] { color: red; }`. This allows for styles to be written that work both with and without the shadowDOM. It also lets you write styles so the intent is clear. Use caution picking the selector argument so that it does not select more than intended after transformation. `::slotted(*)` for instance would select all elements. `::slotted([slot])` is useful for selecting all named slot contents.  
-#### `::part()` 
-The shadow parts API allows selected elements to be exposed for styling outside the shadowDOM. By labeling an element inside the component with a `part=something` attribute it can be selected outside that component with a `the-tag::part(something) {color: red;}` selector. For server rendering this is transformed into `the-tag [part*=something] { color: red; }`. Notice again that this does not stop deep selection. This selector will match any part of the same name nested within. 
+#### `::slotted()`
+With shadowDOM `<slot>`'s child elements in the light DOM are rendered inside the shadowDOM. The `::slotted()` pseudo selector is used inside the shadowDOM to style these elements. Any selector argument will be applied to any matching elements that are slotted. The transform takes rules like `div::slotted([slot=here]) { color:red; }` and returns `div[slot=here] { color: red; }`. This allows for styles to be written that work both with and without the shadowDOM. It also lets you write styles so the intent is clear. Use caution picking the selector argument so that it does not select more than intended after transformation. `::slotted(*)` for instance would select all elements. `::slotted([slot])` is useful for selecting all named slot contents.
+#### `::part()`
+The shadow parts API allows selected elements to be exposed for styling outside the shadowDOM. By labeling an element inside the component with a `part=something` attribute it can be selected outside that component with a `the-tag::part(something) {color: red;}` selector. For server rendering this is transformed into `the-tag [part*=something] { color: red; }`. Notice again that this does not stop deep selection. This selector will match any part of the same name nested within.
 
 #### `scope=global`
-Global unscoped styles can be added to components if desired. If a `scope=global` attribute is added to a style tag the styles will be collected and added to the head tag as with other styles. But no transforms or scoping will be done. These styles are removed from the template tag so that they will not appear inside shadowDOM. 
+Global unscoped styles can be added to components if desired. If a `scope=global` attribute is added to a style tag the styles will be collected and added to the head tag as with other styles. But no transforms or scoping will be done. These styles are removed from the template tag so that they will not appear inside shadowDOM.
 ```html
 <style scope=global>
   /* this rule will be put in the head and */
@@ -126,13 +126,13 @@ Global unscoped styles can be added to components if desired. If a `scope=global
   div { color:red; }
 </style>
 ```
-A style tag that is nested inside a component but is not a direct child will not be transformed or collected at all by the transform. 
+A style tag that is nested inside a component but is not a direct child will not be transformed or collected at all by the transform.
 ```JavaScript
 export default Component({html}){
   return html`
     <div>Hello World</div>
     <script>
-      //this script will be transformed and moved 
+      //this script will be transformed and moved
     </script>
     <div>
       <script>
@@ -143,9 +143,8 @@ export default Component({html}){
 }
 ```
 
-
 ## Style context
-Enhance renders pages by expanding each component instance in the document with their template contents. The templates are also placed into the page for use in the shadowDOM. The styles are transformed for each of these context. The styles transformed for the server rendered output are collected and put in the document head. Any duplicated style tags are removed. The template context styles are left with the template tags for use with the shadowDOM.  
+Enhance renders pages by expanding each component instance in the document with their template contents. The templates are also placed into the page for use in the shadowDOM. The styles are transformed for each of these context. The styles transformed for the server rendered output are collected and put in the document head. Any duplicated style tags are removed. The template context styles are left with the template tags for use with the shadowDOM.
 
 ## API
 Style Transforms are passed as an array. Transforms are called with a single object argument with the following properties:
@@ -156,11 +155,10 @@ Style Transforms are passed as an array. Transforms are called with a single obj
 
 The return value from the transform should be the new string contents of the style tag for the given context.
 
-
 ## More Examples
 ``` html
 //global block
-  <style scope="global"> 
+  <style scope="global">
     div {
        background:blue;
      }
@@ -209,7 +207,7 @@ The return value from the transform should be the new string contents of the sty
   </div>
 ```
 
-## Used like this 
+## Used like this
 ``` html
 <my-element>
   <span>Light</span>

--- a/app/docs/md/reference/libraries/enhance-style-transform.md
+++ b/app/docs/md/reference/libraries/enhance-style-transform.md
@@ -12,7 +12,7 @@ It does not add new syntax. It sets firm upper bound so component styles can't b
 The shadowDOM gives full encapsulation of styles, but breaks other things like forms. When building with components what we want is some reasonable tools to help scope styles to those components. More like caution tape than chain-link fence. If the shadowDOM is used styles can be written once that will work before and after the shadowDOM initializes.
 
 ## limitations
-This approach doesn't completely avoid deep selection of nested elements. It makes tradeoffs to improve scoping without creating other problems. Transformed shadow selectors can also select some unintended elements if they are written to too broadly (i.e. `::slotted(*)` will select all children). If you prefer a bullet proof style encapsulation and are willing to accept the downsides (broken forms, FOUC, etc.) use the shadowDOM.   
+This approach doesn't completely avoid deep selection of nested elements. It makes tradeoffs to improve scoping without creating other problems. Transformed shadow selectors can also select some unintended elements if they are written to too broadly (i.e. `::slotted(*)` will select all children). If you prefer a bullet-proof style encapsulation and are willing to accept the downsides (broken forms, FOUC, etc.) use the shadowDOM.   
 ## Other Recommendations
 - Use with utility classes.
   This transform works well with utility class styles. We recommend writing most styles as utility classes directly on the elements in your template. This only leaves styles that cannot be written as utility classes which can be added to the component.

--- a/app/docs/md/reference/libraries/enhance-style-transform.md
+++ b/app/docs/md/reference/libraries/enhance-style-transform.md
@@ -17,7 +17,7 @@ This approach doesn't completely avoid deep selection of nested elements. It mak
 - Use with utility classes.
   This transform works well with utility class styles. We recommend writing most styles as utility classes directly on the elements in your template. This only leaves styles that cannot be written as utility classes which can be added to the component.
 - Use specific selectors to avoid deep selecting.
-  It is better to use the `>` child selector rather than the general descendent selector when possible(i.e. `:host > div` ). 
+  It is better to use the `>` child selector rather than the general descendant selector when possible(i.e. `:host > div` ). 
 - With slotted and part be specific enough to avoid over selection
   
 

--- a/app/docs/md/unsorted/doc-callout-test.md
+++ b/app/docs/md/unsorted/doc-callout-test.md
@@ -18,7 +18,7 @@ This 👇 code block is rendered and highlighted on the server with arcdown + hl
 
 ### note (default)
 
-Wouldn’t it be nice if you could author components like HTML pages? Well that’s what you get with Enhance single-file components.
+Wouldn’t it be nice if you could author components like HTML pages? Well that’s what you get with Enhance's single-file components.
 
 </doc-callout>
 
@@ -34,7 +34,7 @@ Add functionality to your component by adding a `<script>` tag. You can either a
 
 ### info
 
-Enhance API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTROY`; these route handlers should return JSON values as browser HTML forms cannot issue these sorts of HTTP requests.
+Enhance's API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTROY`; these route handlers should return JSON values as browser HTML forms cannot issue these sorts of HTTP requests.
 
 </doc-callout>
 
@@ -42,7 +42,7 @@ Enhance API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTROY
 
 ### caution
 
-Enhance API Routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under app/api and follow the same file-based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
+Enhance's API Routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under app/api and follow the same file-based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
 
 </doc-callout>
 

--- a/app/docs/md/unsorted/doc-callout-test.md
+++ b/app/docs/md/unsorted/doc-callout-test.md
@@ -52,7 +52,7 @@ Enhance API Routes are backend JSON routes designed for seamless client-side pro
 
 - when to redirect
 - working with session
-- talking to a third party api
+- talking to a third party API
 - talking to DynamoDB
 
 </doc-callout>

--- a/app/docs/md/unsorted/doc-callout-test.md
+++ b/app/docs/md/unsorted/doc-callout-test.md
@@ -42,7 +42,7 @@ Enhance API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTROY
 
 ### caution
 
-Enhance API Routes are backend JSON routes designed for seamless clientside progressive enhancement. API routes are defined under app/api and follow the same file based routing conventions as app/pages. JSON response values from API routes are automatically passed to coresponding page routes.
+Enhance API Routes are backend JSON routes designed for seamless clientside progressive enhancement. API routes are defined under app/api and follow the same file based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
 
 </doc-callout>
 

--- a/app/docs/md/unsorted/doc-callout-test.md
+++ b/app/docs/md/unsorted/doc-callout-test.md
@@ -42,7 +42,7 @@ Enhance's API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTR
 
 ### caution
 
-Enhance's API Routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under app/api and follow the same file-based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
+Enhance's API Routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under `app/api` and follow the same file-based routing conventions as `app/pages`. JSON response values from API routes are automatically passed to corresponding page routes.
 
 </doc-callout>
 

--- a/app/docs/md/unsorted/doc-callout-test.md
+++ b/app/docs/md/unsorted/doc-callout-test.md
@@ -18,7 +18,7 @@ This 👇 code block is rendered and highlighted on the server with arcdown + hl
 
 ### note (default)
 
-Wouldn’t it be nice if you could author components like HTML pages? Well that’s what you get with Enhance single file components.
+Wouldn’t it be nice if you could author components like HTML pages? Well that’s what you get with Enhance single-file components.
 
 </doc-callout>
 
@@ -42,7 +42,7 @@ Enhance API routes support other HTTP verbs such as `PUT`, `PATCH`, and `DESTROY
 
 ### caution
 
-Enhance API Routes are backend JSON routes designed for seamless clientside progressive enhancement. API routes are defined under app/api and follow the same file based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
+Enhance API Routes are backend JSON routes designed for seamless client-side progressive enhancement. API routes are defined under app/api and follow the same file-based routing conventions as app/pages. JSON response values from API routes are automatically passed to corresponding page routes.
 
 </doc-callout>
 

--- a/app/docs/md/unsorted/doc-code-test.md
+++ b/app/docs/md/unsorted/doc-code-test.md
@@ -55,7 +55,7 @@ class HljsLineWrapper {
 
 <doc-callout level="caution">
 
-The `callout` attribute doesn't work for strings that span hljs tokens.  
+The `callout` attribute doesn't work for strings that span hljs tokens.
 So, `callout="15-return match"` would not work above. "return" is tokenized while " match" is not.
 
 </doc-callout>

--- a/app/docs/md/unsorted/doc-video-test.md
+++ b/app/docs/md/unsorted/doc-video-test.md
@@ -4,7 +4,7 @@ title: Doc Video
 
 ## Video Walkthrough
 
-This is a set of 5 videos that starts at the third in the series.  
+This is a set of 5 videos that starts at the third in the series.
 Most of the videos don't actually work -- it's here to test the series feature in the player
 
 <doc-video playback-id="ADl6wSlpxTpJKym2OhPd2TQsB64nW01x5dygkSEAfNdU" name="Video pt 1: Tutorial">


### PR DESCRIPTION
Changes applied are as follows (each corresponding to its own commit):

- Fix typos (4039752)
- Adjust word separation (e65cd93)
- Fix capitalization of acronyms (b74a1d3)
- Clarify possessives (25ec2fa)
- Various assorted fixes (3f8d42b)
- Fix whitespace (1f08681)

I would strongly recommend reviewing each commit's diff separately, to ensure the highlighting is properly applied so the changes are intelligible.
