### PR TITLE
Fix typo in utility styles doc

### DIFF
--- a/app/docs/md/learn/concepts/styling/utility-classes.md
+++ b/app/docs/md/learn/concepts/styling/utility-classes.md
@@ -21,7 +21,7 @@ During development a stylesheet is generated and served via `/enhance-styles.css
 <doc-callout level="caution">
 
 If you use a [custom Head function](/docs/learn/starter-project/head), `enhance-styles.css` will **not** be included by default.
-To add Enhance Styles utility classes with a custom headm.mjs, it is recommended to use the helper function [described below](#getstyles) to include Enhance Styles.
+To add Enhance Styles utility classes with a custom head.mjs, it is recommended to use the helper function [described below](#getstyles) to include Enhance Styles.
 
 </doc-callout>
 


### PR DESCRIPTION
Just a slight typo I noticed while reading the page.