### PR TITLE
Change port mentioned in Fastify docs

### DIFF
--- a/app/docs/md/learn/deployment/fastify.md
+++ b/app/docs/md/learn/deployment/fastify.md
@@ -102,7 +102,7 @@ export default elements
 
 </doc-code>
 
-Run `npm start`, and preview at `http://localhost:8080`.
+Run `npm start`, and preview at `http://localhost:3000`.
 
 ## Adding a route as plain basic HTML
 


### PR DESCRIPTION
The docs have you setup a server listening on port 3000, but then later mention going to :8080

This fixes that.