### PR TITLE
Fix overflowing issues in callouts

### DIFF
--- a/app/elements/doc/callout.mjs
+++ b/app/elements/doc/callout.mjs
@@ -31,6 +31,9 @@ export default function Callout ({ html, state }) {
       callout-container.callout-thin {
         padding: 0.35rem 0.5rem;
       }
+      callout-container > div {
+        min-width: 0;
+      }
       callout-container pre code {
         border-radius: 0.333rem;
       }


### PR DESCRIPTION
The callouts overflows the screen on mobile screens. The main cause of this issue is the long code blocks in callouts. I fix the issue by giving a `min-width: 0` property to the content `div` of the callout. Because that `div` is a flex item and `min-width: auto` by default, the min width of the `div` is the `min-content` without breaking any text. When we give `min-width: 0`, the element correctly shrinks and a scroll-bar appears for the code content. Also now the inline code can correctly wraps to the next line.

Before: (The callout content overflows)
<img width="402" height="857" alt="image" src="https://github.com/user-attachments/assets/c412f48d-8821-4ae3-b9f2-8ea2b441a8a9" />
After: (The overflowling issue is solved with `min-width` property)
<img width="408" height="853" alt="image" src="https://github.com/user-attachments/assets/64704c31-ee81-4f94-9ee8-89816ac12bde" />
